### PR TITLE
Allow import directly from git rep

### DIFF
--- a/{{ cookiecutter.namespace }}/src/pynwb/{{ cookiecutter.py_pkg_name }}/__init__.py
+++ b/{{ cookiecutter.namespace }}/src/pynwb/{{ cookiecutter.py_pkg_name }}/__init__.py
@@ -1,13 +1,21 @@
 import os
 from pynwb import load_namespaces
+
 # Set path of the namespace.yaml file to the expected install location
-{{ cookiecutter.py_pkg_name }}_specpath = os.path.join(os.path.dirname(__file__), 
-                                                       'spec', 
-                                                       '{{ cookiecutter.namespace }}.namespace.yaml')
-# If the extensions has not been installed yet but we running directly from the git repo
-if not os.path.exists(ndx_icephys_meta_specpath):
-    {{ cookiecutter.py_pkg_name }}_specpath  = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                                            '../../../spec/',
-                                                                            '{{ cookiecutter.namespace }}.namespace.yaml'))
+{{ cookiecutter.py_pkg_name }}_specpath = os.path.join(
+    os.path.dirname(__file__), 
+    'spec', 
+    '{{ cookiecutter.namespace }}.namespace.yaml'
+)
+
+# If the extension has not been installed yet but we are running directly from the git repo
+if not os.path.exists({{ cookiecutter.py_pkg_name }}_specpath):
+    {{ cookiecutter.py_pkg_name }}_specpath = os.path.abspath(os.path.join(
+        os.path.dirname(__file__),
+        '..', '..', '..', 
+        'spec',
+        '{{ cookiecutter.namespace }}.namespace.yaml'
+    ))
+
 # Load the namespace 
 load_namespaces({{ cookiecutter.py_pkg_name }}_specpath)

--- a/{{ cookiecutter.namespace }}/src/pynwb/{{ cookiecutter.py_pkg_name }}/__init__.py
+++ b/{{ cookiecutter.namespace }}/src/pynwb/{{ cookiecutter.py_pkg_name }}/__init__.py
@@ -1,4 +1,13 @@
 import os
 from pynwb import load_namespaces
-{{ cookiecutter.py_pkg_name }}_specpath = os.path.join(os.path.dirname(__file__), 'spec', '{{ cookiecutter.namespace }}.namespace.yaml')
+# Set path of the namespace.yaml file to the expected install location
+{{ cookiecutter.py_pkg_name }}_specpath = os.path.join(os.path.dirname(__file__), 
+                                                       'spec', 
+                                                       '{{ cookiecutter.namespace }}.namespace.yaml')
+# If the extensions has not been installed yet but we running directly from the git repo
+if not os.path.exists(ndx_icephys_meta_specpath):
+    {{ cookiecutter.py_pkg_name }}_specpath  = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                                            '../../../spec/',
+                                                                            '{{ cookiecutter.namespace }}.namespace.yaml'))
+# Load the namespace 
 load_namespaces({{ cookiecutter.py_pkg_name }}_specpath)


### PR DESCRIPTION
Update the default setup.py to support usage of extensions directly from the GitHub repo without installing the extension yet. This is useful during development.