### PR TITLE
Update generated requirements.txt which should use pinned reqs

### DIFF
--- a/{{ cookiecutter.namespace }}/requirements.txt
+++ b/{{ cookiecutter.namespace }}/requirements.txt
@@ -1,3 +1,4 @@
-pynwb>=1.5.0,<3
-hdmf>=2.5.6,<4
-hdmf_docutils>=0.4.4,<1
+# pinned dependencies to reproduce a working development environment
+hdmf_docutils==0.4.4
+hdmf==3.1.1
+pynwb==2.0.0


### PR DESCRIPTION
See also https://nvie.com/posts/pin-your-packages/
This is useful for ensuring a working development environment as new versions of dependencies are released.

`setup.py` will continue to list a range of acceptable dependency versions. 