### PR TITLE
Clean up sdist and build instructions

### DIFF
--- a/{{ cookiecutter.namespace }}/pyproject.toml
+++ b/{{ cookiecutter.namespace }}/pyproject.toml
@@ -50,16 +50,9 @@ dependencies = [
 # "Discussions" = "https://github.com/organization/package/discussions"
 # "Changelog" = "https://github.com/organization/package/blob/main/CHANGELOG.md"
 
-[tool.hatch.build]
-include = [
-    "src/pynwb",
-    "spec/{{ cookiecutter.namespace }}.extensions.yaml",
-    "spec/{{ cookiecutter.namespace }}.namespace.yaml",
-]
-exclude = [
-    "src/pynwb/tests",
-]
-
+# Include only the source code under src/pynwb/{{ cookiecutter.py_pkg_name }} and the spec files under spec.
+# Install the spec files in the wheel under the {{ cookiecutter.py_pkg_name }} package.
+# {{ cookiecutter.py_pkg_name }}/__init__.py will look there first for the spec files.
 [tool.hatch.build.targets.wheel]
 packages = [
     "src/pynwb/{{ cookiecutter.py_pkg_name }}",
@@ -70,13 +63,9 @@ packages = [
 "spec" = "{{ cookiecutter.py_pkg_name }}/spec"
 
 [tool.hatch.build.targets.sdist]
-include = [
-    "src/pynwb",
-    "spec/{{ cookiecutter.namespace }}.extensions.yaml",
-    "spec/{{ cookiecutter.namespace }}.namespace.yaml",
-    "docs",
+exclude = [
+    ".git*",
 ]
-exclude = []
 
 [tool.pytest.ini_options]
 # uncomment below to run pytest always with code coverage reporting. NOTE: breakpoints may not work

--- a/{{ cookiecutter.namespace }}/pyproject.toml
+++ b/{{ cookiecutter.namespace }}/pyproject.toml
@@ -50,18 +50,26 @@ dependencies = [
 # "Discussions" = "https://github.com/organization/package/discussions"
 # "Changelog" = "https://github.com/organization/package/blob/main/CHANGELOG.md"
 
-# Include only the source code under src/pynwb/{{ cookiecutter.py_pkg_name }} and the spec files under spec.
-# Install the spec files in the wheel under the {{ cookiecutter.py_pkg_name }} package.
-# {{ cookiecutter.py_pkg_name }}/__init__.py will look there first for the spec files.
+# Include only the source code under `src/pynwb/{{ cookiecutter.py_pkg_name }}` and the spec files under `spec`
+# in the wheel.
 [tool.hatch.build.targets.wheel]
 packages = [
     "src/pynwb/{{ cookiecutter.py_pkg_name }}",
     "spec"
 ]
 
+# Rewrite the path to the `spec` directory to `{{ cookiecutter.py_pkg_name }}/spec`.
+# `{{ cookiecutter.py_pkg_name }}/__init__.py` will look there first for the spec files.
+# The resulting directory structure within the wheel will be:
+# {{ cookiecutter.py_pkg_name }}/
+# ├── __init__.py
+# ├── spec
+# └── widgets
 [tool.hatch.build.targets.wheel.sources]
 "spec" = "{{ cookiecutter.py_pkg_name }}/spec"
 
+# The source distribution includes everything in the package except for the `src/matnwb` directory and
+# git and github-related files.
 [tool.hatch.build.targets.sdist]
 exclude = [
     ".git*",

--- a/{{ cookiecutter.namespace }}/pyproject.toml
+++ b/{{ cookiecutter.namespace }}/pyproject.toml
@@ -65,6 +65,7 @@ packages = [
 [tool.hatch.build.targets.sdist]
 exclude = [
     ".git*",
+    "src/matnwb",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
The build instructions in `pyproject.toml` were confusing. In addition, the sdist did not include all the files that document the package, such as the changelog and requirements files.

Before:
```
❯ tar -xzvf ndx_pose-0.2.0.tar.gz 
x ndx_pose-0.2.0/docs/Makefile
x ndx_pose-0.2.0/docs/README.md
x ndx_pose-0.2.0/docs/make.bat
x ndx_pose-0.2.0/docs/source/conf.py
x ndx_pose-0.2.0/docs/source/conf_doc_autogen.py
x ndx_pose-0.2.0/docs/source/credits.rst
x ndx_pose-0.2.0/docs/source/description.rst
x ndx_pose-0.2.0/docs/source/format.rst
x ndx_pose-0.2.0/docs/source/index.rst
x ndx_pose-0.2.0/docs/source/release_notes.rst
x ndx_pose-0.2.0/docs/source/_static/theme_overrides.css
x ndx_pose-0.2.0/spec/ndx-pose.extensions.yaml
x ndx_pose-0.2.0/spec/ndx-pose.namespace.yaml
x ndx_pose-0.2.0/src/pynwb/README.md
x ndx_pose-0.2.0/src/pynwb/ndx_pose/__init__.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/pose.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/io/__init__.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/io/pose.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/testing/mock/__init__.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/testing/mock/pose.py
x ndx_pose-0.2.0/src/pynwb/tests/__init__.py
x ndx_pose-0.2.0/src/pynwb/tests/test_example_usage.py
x ndx_pose-0.2.0/src/pynwb/tests/back_compat/generate_data_0.1.1.py
x ndx_pose-0.2.0/src/pynwb/tests/back_compat/test_read.py
x ndx_pose-0.2.0/src/pynwb/tests/integration/hdf5/__init__.py
x ndx_pose-0.2.0/src/pynwb/tests/integration/hdf5/test_pose.py
x ndx_pose-0.2.0/src/pynwb/tests/unit/__init__.py
x ndx_pose-0.2.0/src/pynwb/tests/unit/test_pose.py
x ndx_pose-0.2.0/.gitignore
x ndx_pose-0.2.0/LICENSE.txt
x ndx_pose-0.2.0/README.md
x ndx_pose-0.2.0/pyproject.toml
x ndx_pose-0.2.0/PKG-INFO
```

After:
```
❯ tar -xzvf ndx_pose-0.2.0.tar.gz 
x ndx_pose-0.2.0/CHANGELOG.md
x ndx_pose-0.2.0/requirements-dev.txt
x ndx_pose-0.2.0/requirements-min.txt
x ndx_pose-0.2.0/docs/Makefile
x ndx_pose-0.2.0/docs/README.md
x ndx_pose-0.2.0/docs/make.bat
x ndx_pose-0.2.0/docs/source/conf.py
x ndx_pose-0.2.0/docs/source/conf_doc_autogen.py
x ndx_pose-0.2.0/docs/source/credits.rst
x ndx_pose-0.2.0/docs/source/description.rst
x ndx_pose-0.2.0/docs/source/format.rst
x ndx_pose-0.2.0/docs/source/index.rst
x ndx_pose-0.2.0/docs/source/release_notes.rst
x ndx_pose-0.2.0/docs/source/_static/theme_overrides.css
x ndx_pose-0.2.0/spec/ndx-pose.extensions.yaml
x ndx_pose-0.2.0/spec/ndx-pose.namespace.yaml
x ndx_pose-0.2.0/src/matnwb/README.md
x ndx_pose-0.2.0/src/pynwb/README.md
x ndx_pose-0.2.0/src/pynwb/ndx_pose/__init__.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/pose.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/io/__init__.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/io/pose.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/testing/mock/__init__.py
x ndx_pose-0.2.0/src/pynwb/ndx_pose/testing/mock/pose.py
x ndx_pose-0.2.0/src/pynwb/tests/__init__.py
x ndx_pose-0.2.0/src/pynwb/tests/test_example_usage.py
x ndx_pose-0.2.0/src/pynwb/tests/back_compat/generate_data_0.1.1.py
x ndx_pose-0.2.0/src/pynwb/tests/back_compat/test_read.py
x ndx_pose-0.2.0/src/pynwb/tests/integration/hdf5/__init__.py
x ndx_pose-0.2.0/src/pynwb/tests/integration/hdf5/test_pose.py
x ndx_pose-0.2.0/src/pynwb/tests/unit/__init__.py
x ndx_pose-0.2.0/src/pynwb/tests/unit/test_pose.py
x ndx_pose-0.2.0/src/spec/create_extension_spec.py
x ndx_pose-0.2.0/.gitignore
x ndx_pose-0.2.0/LICENSE.txt
x ndx_pose-0.2.0/README.md
x ndx_pose-0.2.0/pyproject.toml
x ndx_pose-0.2.0/PKG-INFO
```

This PR cleans up `pyproject.toml` to include those the missing files, remove the global build configuration which is [not recommended by hatch](https://hatch.pypa.io/latest/config/build/#build-targets), and adds some comments.

Thanks @h-mayorquin