### PR TITLE
Remove windows-specific installation instructions for cookiecutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MATLAB support is in development.
 
 1. Install [Python](https://www.python.org/downloads/) for your operating system if it is not already installed.
 
-2. Install [cookiecutter](https://pypi.org/project/cookiecutter/) (see [here](https://cookiecutter.readthedocs.io/en/latest/installation.html) for Windows install instructions), [pynwb](https://pypi.org/project/pynwb/), and [hdmf-docutils](https://pypi.org/project/hdmf-docutils/).
+2. Install [cookiecutter](https://pypi.org/project/cookiecutter/), [pynwb](https://pypi.org/project/pynwb/), and [hdmf-docutils](https://pypi.org/project/hdmf-docutils/).
 `cookiecutter` is a Python-based command-line utility that creates projects from templates.
    ```bash
    python -m pip install -U cookiecutter pynwb hdmf-docutils


### PR DESCRIPTION
Remove windows-specific installation instructions for cookiecutter from readme. They appear to no longer be necessary.