### PR TITLE
Make workflows trigger on PR and push to main

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,9 @@
 name: Codespell
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,8 +1,11 @@
 name: Run tests
 on:
+  push:
+    branches:
+      - main
+  pull_request:
   schedule:
     - cron: '0 5 * * *'  # once per day at midnight ET
-  push:
   workflow_dispatch:
 
 jobs:

--- a/{{ cookiecutter.namespace }}/.github/workflows/check_external_links.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/check_external_links.yml
@@ -1,6 +1,9 @@
 name: Check Sphinx external links
 on:
   push:
+    branches:
+      - main
+  pull_request:
   schedule:
     - cron: '0 5 * * 0'  # once every Sunday at midnight ET
   workflow_dispatch:

--- a/{{ cookiecutter.namespace }}/.github/workflows/codespell.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/codespell.yml
@@ -1,6 +1,9 @@
 name: Codespell
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/{{ cookiecutter.namespace }}/.github/workflows/ruff.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/ruff.yml
@@ -1,6 +1,9 @@
 name: Ruff
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
@@ -1,6 +1,9 @@
 name: Run all tests
 on:
   push:
+    branches:
+      - main
+  pull_request:
   schedule:
     - cron: '0 5 * * 0'  # once every Sunday at midnight ET
   workflow_dispatch:

--- a/{{ cookiecutter.namespace }}/.github/workflows/run_coverage.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/run_coverage.yml
@@ -1,6 +1,9 @@
 name: Run code coverage
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/{{ cookiecutter.namespace }}/.github/workflows/validate_schema.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/validate_schema.yml
@@ -1,6 +1,8 @@
 name: Validate schema
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
- The validate schema workflow was running twice in ndx repos.
- The workflows were not running on PRs from forks

This PR fixes both issues. Workflows should run on pushes to main and pushes to and creation of PRs, including from forks.