### PR TITLE
Use recommended method for running batch script on windows

### DIFF
--- a/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
@@ -89,6 +89,6 @@ jobs:
         if: ${{ "{{" }} matrix.os == 'windows-latest' }}
         run: |
           python -m venv test-wheel-env
-          test-wheel-env/Scripts/activate.bat
+          call test-wheel-env/Scripts/activate.bat
           python -m pip install dist/*-none-any.whl
           python -c "import {{ cookiecutter.py_pkg_name }}"


### PR DESCRIPTION
See Copilot recommendation here: https://github.com/LorenFrankLab/ndx-franklab-novela/pull/11#discussion_r2146842430

Based on my research, it does seem like when calling a batch script within another script, prefixing the batch script command with `call` is recommended to ensure control returns to the caller for subsequent commands.