### PR TITLE
Make run_all_tests workflow robust to test deps

### DIFF
--- a/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
@@ -160,7 +160,10 @@ jobs:
       - name: Checkout repo to access tests
         uses: actions/checkout@v4
 
-      - name: Install pytest and run tests
+      - name: Install test dependencies from pyproject.toml and run tests
         run: |
-          python -m pip install pytest
+          python -c "import tomllib; import subprocess; import sys; \
+              data=tomllib.load(open('pyproject.toml','rb')); \
+              deps=data['project']['optional-dependencies']['test']; \
+              subprocess.run([sys.executable, '-m', 'pip', 'install'] + deps)"
           pytest -v


### PR DESCRIPTION
When a project's test dependencies include more than pytest, the run_all_tests workflow currently will not install them. This PR fixes that issue.