### PR TITLE
Use dev dependency groups and bump minimum Python version to 3.10

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run PyNWB tests from generated extension
         run: |
           cd ./out/ndx-my-namespace
-          python -m pip install -U --groups dev .
+          python -m pip install -U --group dev .
           pytest
 
       - name: Run ruff on generated extension

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,18 +24,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { name: linux-python3.9    , os: ubuntu-latest  , python-ver: "3.9"  }
+        - { name: linux-python3.10   , os: ubuntu-latest  , python-ver: "3.10" }
         - { name: linux-python3.13   , os: ubuntu-latest  , python-ver: "3.13" }
-        - { name: windows-python3.9  , os: windows-latest , python-ver: "3.9"  }
+        - { name: windows-python3.10 , os: windows-latest , python-ver: "3.10" }
         - { name: windows-python3.13 , os: windows-latest , python-ver: "3.13" }
-        - { name: macos-python3.9    , os: macos-latest   , python-ver: "3.9"  }
+        - { name: macos-python3.10   , os: macos-latest   , python-ver: "3.10" }
         - { name: macos-python3.13   , os: macos-latest   , python-ver: "3.13" }
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-ver }}
 
@@ -66,7 +66,7 @@ jobs:
       - name: Run PyNWB tests from generated extension
         run: |
           cd ./out/ndx-my-namespace
-          python -m pip install -U ".[dev]"
+          python -m pip install -U --groups dev .
           pytest
 
       - name: Run ruff on generated extension

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo provides a template for creating Neurodata Extensions (NDX) for the
 [Neurodata Without Borders](https://nwb.org/)
  data standard.
 
-This template currently supports creating Neurodata Extensions only using Python 3.9+.
+This template currently supports creating Neurodata Extensions only using Python 3.10+.
 MATLAB support is in development.
 
 ## Getting started
@@ -68,7 +68,7 @@ When answering the cookiecutter prompts, you will be asked whether you would lik
 3. Copy [`tetrode_series_widget.py`](https://github.com/nwb-extensions/ndx-template/blob/main/%7B%7B%20cookiecutter.namespace%20%7D%7D/src/pynwb/%7B%7B%20cookiecutter.py_pkg_name%20%7D%7D/widgets/tetrode_series_widget.py) to that directory and adapt the contents to your extension.
 4. Create a directory named `notebooks` in the root of the repository.
 5. Copy [example.ipynb](https://github.com/nwb-extensions/ndx-template/blob/main/%7B%7B%20cookiecutter.namespace%20%7D%7D/notebooks/example.ipynb) to that directory and adapt the contents to your extension.
-6. Add `nwbwidgets` to the `[project] dependencies` or `[project.optional-dependencies]` section of `pyproject.toml`.
+6. Add `nwbwidgets` to the `[project] dependencies` or `[dependency-groups]` section of `pyproject.toml`.
 
 ## Maintainers
 - [@rly](https://github.com/rly)

--- a/{{ cookiecutter.namespace }}/.github/workflows/check_external_links.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/check_external_links.yml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Install Sphinx dependencies and package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -U ".[docs]"
+          python -m pip install -U --groups docs .
           python -m pip list
 
       - name: Check Sphinx external links

--- a/{{ cookiecutter.namespace }}/.github/workflows/check_external_links.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/check_external_links.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Sphinx dependencies and package
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -U --groups docs .
+          python -m pip install -U --group docs .
           python -m pip list
 
       - name: Check Sphinx external links

--- a/{{ cookiecutter.namespace }}/.github/workflows/codespell.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/codespell.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/{{ cookiecutter.namespace }}/.github/workflows/ruff.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/ruff.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Ruff
         uses: astral-sh/ruff-action@v3

--- a/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
@@ -29,20 +29,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.9-minimum      , requirements: minimum    , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-python3.9              , requirements: upgraded   , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: linux-python3.10-minimum     , requirements: minimum    , python-ver: "3.10", os: ubuntu-latest }
           - { name: linux-python3.10             , requirements: upgraded   , python-ver: "3.10", os: ubuntu-latest }
           - { name: linux-python3.11             , requirements: upgraded   , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.12             , requirements: upgraded   , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.13             , requirements: upgraded   , python-ver: "3.13", os: ubuntu-latest }
-          - { name: windows-python3.9-minimum    , requirements: minimum    , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-python3.9            , requirements: upgraded   , python-ver: "3.9" , os: windows-latest }
+          - { name: windows-python3.10-minimum   , requirements: minimum    , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.10           , requirements: upgraded   , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.11           , requirements: upgraded   , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.12           , requirements: upgraded   , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.13           , requirements: upgraded   , python-ver: "3.13", os: windows-latest }
-          - { name: macos-python3.9-minimum      , requirements: minimum    , python-ver: "3.9" , os: macos-latest }
-          - { name: macos-python3.9              , requirements: upgraded   , python-ver: "3.9" , os: macos-latest }
+          - { name: macos-python3.10-minimum     , requirements: minimum    , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.10             , requirements: upgraded   , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11             , requirements: upgraded   , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.12             , requirements: upgraded   , python-ver: "3.12", os: macos-latest }
@@ -62,7 +59,7 @@ jobs:
         if: ${{ "{{" }} matrix.requirements == 'minimum' }}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[min-reqs,test]"
+          python -m pip install . --group test-min-deps
           python -m pip list
           python -m pip check
 
@@ -71,7 +68,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # force upgrade of all dependencies to latest versions within allowed range
-          python -m pip install -U ".[test]"
+          python -m pip install -U . --group test
           python -m pip list
           python -m pip check
 
@@ -162,8 +159,5 @@ jobs:
 
       - name: Install test dependencies from pyproject.toml and run tests
         run: |
-          python -c "import tomllib; import subprocess; import sys; \
-              data=tomllib.load(open('pyproject.toml','rb')); \
-              deps=data['project']['optional-dependencies']['test']; \
-              subprocess.run([sys.executable, '-m', 'pip', 'install'] + deps)"
+          python -m pip install --group test
           pytest -v

--- a/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/run_all_tests.yml
@@ -46,12 +46,12 @@ jobs:
           - { name: macos-python3.13             , requirements: upgraded   , python-ver: "3.13", os: macos-latest }
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ "{{" }} matrix.python-ver }}
 
@@ -79,11 +79,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # tags are required to determine the version
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"  # use the latest stable version of Python
 
@@ -94,7 +94,7 @@ jobs:
           twine check dist/*
 
       - name: Upload wheel and sdist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -103,7 +103,7 @@ jobs:
         run: mkdir archive && git archive -v -o archive/archive.tgz HEAD
 
       - name: Upload git archive artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: archive
           path: archive/
@@ -117,19 +117,19 @@ jobs:
     steps:
       - name: Download sdist and wheel artifacts
         if: matrix.package != 'archive'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
 
       - name: Download git archive artifact
         if: matrix.package == 'archive'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: archive
           path: archive/
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"  # use the latest stable version of Python
 
@@ -155,7 +155,7 @@ jobs:
         run: python -c "import {{ cookiecutter.py_pkg_name }}"
 
       - name: Checkout repo to access tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install test dependencies from pyproject.toml and run tests
         run: |

--- a/{{ cookiecutter.namespace }}/.github/workflows/run_coverage.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/run_coverage.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # force upgrade of all dependencies to latest versions within allowed range
-          python -m pip install -U --groups test .
+          python -m pip install -U --group test .
           python -m pip list
           python -m pip check
       - name: Run tests and generate coverage report

--- a/{{ cookiecutter.namespace }}/.github/workflows/run_coverage.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/run_coverage.yml
@@ -27,12 +27,12 @@ jobs:
       PYTHON: '3.13'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # tags are required to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ "{{" }} env.PYTHON }}
 
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # force upgrade of all dependencies to latest versions within allowed range
-          python -m pip install -U ".[test]"
+          python -m pip install -U --groups test .
           python -m pip list
           python -m pip check
       - name: Run tests and generate coverage report

--- a/{{ cookiecutter.namespace }}/.github/workflows/validate_schema.yml
+++ b/{{ cookiecutter.namespace }}/.github/workflows/validate_schema.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/{{ cookiecutter.namespace }}/pyproject.toml
+++ b/{{ cookiecutter.namespace }}/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{% for name, email in zip(cookiecutter.author.split(','), cookiecutte
 ]
 description = "{{ cookiecutter.description }}"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 {%- if cookiecutter.license != 'Other' %}
 license = "{{ cookiecutter.license }}"
 {%- else %}
@@ -19,7 +19,6 @@ license = "{{ cookiecutter.license }}"
 classifiers = [
     # TODO: update these classifiers before release
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -46,7 +45,14 @@ dependencies = [
     "hdmf>=3.14.1",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
+# minimum versions of project dependencies for testing (see .github/workflows/run_all_tests.yml)
+test-min-deps = [
+    "pynwb==2.8.0",
+    "hdmf==3.14.1",
+    {include-group = "test"},
+]
+
 test = [
     "coverage>=7.5.4",
     {%- if cookiecutter.widgets -%}
@@ -67,13 +73,8 @@ dev = [
     "codespell>=2.3.0",
     "pre-commit>=3.5.0",
     "ruff>=0.4.10",
-    "{{ cookiecutter.namespace }}[docs,test]",
-]
-
-# minimum requirements of project dependencies for testing (see .github/workflows/run_all_tests.yml)
-min-reqs = [
-    "pynwb==2.8.0",
-    "hdmf==3.14.1",
+    {include-group = "docs"},
+    {include-group = "test"},
 ]
 
 # TODO: add URLs before release


### PR DESCRIPTION
This PR modernizes the generated project's dependency management by adopting [PEP 735](https://peps.python.org/pep-0735/) dependency groups, which is the standardized replacement for using optional-dependencies for development workflows. Dependency groups are designed specifically for development dependencies (test, docs, dev) that should not be published or installed by end users. This change requires [pip 25.1+](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-group) which added support for the `--group` flag in April 2025 but this is fine for the actions and I think for most users.

The changes include: moving `test`, `docs`, and `dev` from `[project.optional-dependencies]` to `[dependency-groups]` in pyproject.toml. renaming `min-reqs` to `test-min-deps` as a dependency group that includes the test group via the `include-group` directive; updating the GitHub Actions workflow to use `pip install --group <name>` syntax.

In addition I am taking the opportunity of bumping the minimum Python version from 3.9 to 3.10 (removing python 3.9)
